### PR TITLE
changed "link" in partnerships to make it match the selected language…

### DIFF
--- a/dictionaries/en.ts
+++ b/dictionaries/en.ts
@@ -273,6 +273,7 @@ export const enDictionary: Dictionary = {
         partners: {
             title: "Our partner companies",
             text: "Telecom Etude has partner companies. These partnerships with companies allow us to benefit from practical training, to lend our premises for their events, and to establish solid professional relationships. As students, this is a unique opportunity to acquire skills while discovering the business world. It strengthens our future opportunities and develops our network",
+            linkWord: "Link",
             bain: {
                 type: "Consulting firm",
                 text: "Bain & Company is the international consulting firm that helps ambitious managers transform their companies into pioneers of tomorrow's world. This prestigious partnership enables us to put Telecom Paris students in touch with Bain & Company consultants and recruiters through special events.",

--- a/dictionaries/fr.ts
+++ b/dictionaries/fr.ts
@@ -297,6 +297,7 @@ export const frDictionary = {
         partners: {
             title: "Nos entreprises partenaires",
             text: "Telecom Etude possède des entreprises partenaires. Ces partenariats avec des entreprises nous permettent de bénéficier de formations pratiques, de prêter nos locaux pour leurs événements, et d'établir des relations professionnelles solides. En tant qu'étudiants, c'est une occasion unique d'acquérir des compétences tout en découvrant le monde de l'entreprise. Cela renforce nos opportunités futures et développe notre réseau.",
+            linkWord: "Lien",
             kpmg: {
                 type: "Audit et conseil",
                 text: "Notre partenariat avec KPMG s'inscrit dans une volonté de bénéficier aux deux parties. Telecom Etude participe au rayonnement de KPMG auprès des étudiants, en contrepartie KPMG organise en collaboration avec Telecom Etude des évènements à destination des étudiants dans les locaux de Telecom durant l'année afin de faire découvrir les métiers du conseil, ainsi qu'une visite des locaux de KPMG en fin d'année accompagné d'un échange en petits groupes.",

--- a/src/app/[locale]/(static)/(client)/partners/page.tsx
+++ b/src/app/[locale]/(static)/(client)/partners/page.tsx
@@ -25,9 +25,10 @@ interface PartnerProps {
     logo: StaticImport;
     t: { text: string; type: string };
     url: string;
+    linkWord: string;
 }
 
-function Partner({ title, logo, t, url }: PartnerProps) {
+function Partner({ title, logo, t, url, linkWord }: PartnerProps) {
     return (
         <section className="p-4">
             <div className="p-[2px] rounded-lg bg-gradient-to-tl from-primary to-destructive">
@@ -39,11 +40,13 @@ function Partner({ title, logo, t, url }: PartnerProps) {
                         <div className="flex flex-col items-center">
                             <p>{t.type}</p>
                             <BtnLink href={url} target="blank" className="flex items-center space-x-1">
-                                <p>Link</p>
+                                <p>{linkWord}</p>
                                 <MdOpenInNew />
                             </BtnLink>
                             <Separator className="my-6" />
-                            <Image src={logo} alt={title + " logo"} width={400} />
+                            <a href={url} target="_blank" rel="noopener noreferrer">
+                                <Image src={logo} alt={title + " logo"} width={400} />
+                            </a>
                         </div>
                         <Separator className="my-6" />
                         <p>{t.text}</p>
@@ -65,9 +68,9 @@ export default function Page({ params: { locale } }: LocaleParams) {
                 <p className="text-lg max-w-[500px] text-center">{t.text}</p>
             </header>
             <div className="grid grid-cols-1 md:grid-cols-3">
-                <Partner title="KPMG" url="https://www.kpmg.com" logo={KPMG} t={t.kpmg} />
-                <Partner title="BearingPoint" url="https://www.bearingpoint.com" logo={BearingPoint} t={t.bearingPoint} />
-                <Partner title="Bain" url="https://www.bain.com" logo={Bain} t={t.bain} />
+                <Partner title="KPMG" linkWord={t.linkWord} url="https://www.kpmg.com" logo={KPMG} t={t.kpmg} />
+                <Partner title="BearingPoint" linkWord={t.linkWord} url="https://www.bearingpoint.com" logo={BearingPoint} t={t.bearingPoint} />
+                <Partner title="Bain" linkWord={t.linkWord} url="https://www.bain.com" logo={Bain} t={t.bain} />
             </div>
         </Block>
     );


### PR DESCRIPTION
… (#13)

* first step toward trying to not close the dropdown labels

* used the multiple selector shadcn ui expansion instead of combobox, there remains modifications to do but it's on the way

* finised redesigning the component with the right themes and colors, removed the limit of 3 because I saw no use in it, and there were conflicts between the component behavior and the previous handling of this limit

* changed the speed of animation in call2action, for it was way too fast in my opinion in the case of a rather serious website

* added linkWord in the dictionaries to use it in partnerships instead of having the word 'link' used in all languages

* added the link on the images